### PR TITLE
Add the "info" command

### DIFF
--- a/brainframe/cli/commands/__init__.py
+++ b/brainframe/cli/commands/__init__.py
@@ -2,4 +2,5 @@ from .backup import backup
 from .compose import compose
 from .install import install
 from .update import update
+from .info import info
 from .utils import by_name

--- a/brainframe/cli/commands/info.py
+++ b/brainframe/cli/commands/info.py
@@ -1,0 +1,38 @@
+from argparse import ArgumentParser
+
+import i18n
+
+from brainframe.cli import env_vars, print_utils
+from .utils import subcommand_parse_args, command
+
+
+@command("info")
+def info():
+    args = _parse_args()
+
+    fields = {
+        "install_path": env_vars.install_path.get(),
+        "data_path": env_vars.data_path.get(),
+    }
+
+    if args.field is None:
+        # Print all fields
+        for name, value in fields.items():
+            print(f"{name}: {value}")
+    elif args.field in fields:
+        # Print just this field's value
+        print(fields[args.field])
+    else:
+        print_utils.fail_translate("info.no-such-field", field=args.field)
+
+
+def _parse_args():
+    parser = ArgumentParser(
+        description=i18n.t("info.description"), usage=i18n.t("info.usage")
+    )
+
+    parser.add_argument(
+        "field", default=None, nargs="?", help=i18n.t("info.field-help")
+    )
+
+    return subcommand_parse_args(parser)

--- a/brainframe/cli/translations/info.en.yml
+++ b/brainframe/cli/translations/info.en.yml
@@ -1,0 +1,7 @@
+en:
+  description: "Provides information on the current BrainFrame server
+  installation."
+  usage: "brainframe info <field>"
+  field-help: "If provided, only the value of this field will be printed"
+
+  no-such-field: "No field with name \"%{field}\" exists"

--- a/brainframe/cli/translations/info.en.yml
+++ b/brainframe/cli/translations/info.en.yml
@@ -1,5 +1,5 @@
 en:
-  description: "Provides information on the current BrainFrame server
+  description: "Provides information about the current BrainFrame server
   installation."
   usage: "brainframe info <field>"
   field-help: "If provided, only the value of this field will be printed"

--- a/brainframe/cli/translations/portal.en.yml
+++ b/brainframe/cli/translations/portal.en.yml
@@ -8,6 +8,7 @@ en:
       install      Installs the BrainFrame server
       backup       Backs up all persistent data for the server
       update       Updates the BrainFrame server to a new version
+      info         Provides information about the BrainFrame server
       compose      Runs all following commands and flags through docker-compose
 
     Examples:


### PR DESCRIPTION
This command provides information on the BrainFrame server installation. Right now, it only provides the currently configured install and data directories.

Users can run `brainframe info` to get all available information or run `brainframe info <field>` for the value of a specific field. This second option is intended to make scripting easier.