### PR TITLE
Fix input line wrapping bug

### DIFF
--- a/brainframe/cli/print_utils.py
+++ b/brainframe/cli/print_utils.py
@@ -20,6 +20,14 @@ class Color(Enum):
     UNDERLINE = "\033[4m"
 
 
+# These delimiters tell GNU readline that any characters between them are
+# non-visible. These should be put before and after ASCII escape codes. Without
+# these, escape codes mess up readline's text wrapping support.
+# See: https://superuser.com/a/301355
+_NON_VISIBLE_START = "\001"
+_NON_VISIBLE_END = "\002"
+
+
 def ask_yes_no(message_id, **kwargs) -> bool:
     """Prompts the user with a yes or no question. The default value is yes.
 
@@ -74,13 +82,23 @@ def fail(message, **kwargs):
 
 
 def print_color(message, color: Color, **kwargs) -> None:
-    color = _check_no_color(color)
-    print(f"{color.value}{message}{Color.END.value}", **kwargs)
+    print(_add_color_codes(message, color), **kwargs)
 
 
 def input_color(message, color: Color) -> str:
+    return input(_add_color_codes(message, color))
+
+
+def _add_color_codes(message, color: Color) -> str:
+    """Wraps the given message in the correct escape codes for the provided
+    color.
+    """
     color = _check_no_color(color)
-    return input(f"{color.value}{message}{Color.END.value}")
+    return (
+        f"{_NON_VISIBLE_START}{color.value}{_NON_VISIBLE_END}"
+        f"{message}"
+        f"{_NON_VISIBLE_START}{Color.END.value}{_NON_VISIBLE_END}"
+    )
 
 
 def _check_no_color(color: Color) -> Color:
@@ -108,3 +126,7 @@ _BRAINFRAME_ART = r"""
                                         Installer
 
 """
+
+# Importing readline has the side-effect of augmenting the `input` function
+# with GNU readline features.
+_ = readline

--- a/brainframe/cli/print_utils.py
+++ b/brainframe/cli/print_utils.py
@@ -82,19 +82,15 @@ def fail(message, **kwargs):
 
 
 def print_color(message, color: Color, **kwargs) -> None:
-    print(_add_color_codes(message, color), **kwargs)
+    color = _check_no_color(color)
+    print(f"{color.value}{message}{Color.END.value}", **kwargs)
 
 
 def input_color(message, color: Color) -> str:
-    return input(_add_color_codes(message, color))
-
-
-def _add_color_codes(message, color: Color) -> str:
-    """Wraps the given message in the correct escape codes for the provided
-    color.
-    """
     color = _check_no_color(color)
-    return (
+    # See https://superuser.com/a/301355 for why these non-visible delimiters
+    # are necessary for input()
+    return input(
         f"{_NON_VISIBLE_START}{color.value}{_NON_VISIBLE_END}"
         f"{message}"
         f"{_NON_VISIBLE_START}{Color.END.value}{_NON_VISIBLE_END}"


### PR DESCRIPTION
On most terminals, line wrapping would not work properly when using the `input` function with GNU readline and color escape codes. This PR adds special delimiters around the escape codes, signaling to readline that these are non-visible characters and un-confusing its line wrapping functionality.