### PR TITLE
Use Poetry to install and run linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,8 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - checkout
-      - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
-          | python3 - --version 1.1.0b2
+      - run: "curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
+          | python3 - --version 1.1.0b2"
       - run: poetry install
       - run: black --check .
       - run: mypy -p "brainframe.cli"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - checkout
-      - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+      - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
+          | python3 - --version 1.1.0b2
       - run: poetry install
       - run: black --check .
       - run: mypy -p "brainframe.cli"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
 
     steps:
       - checkout
-      - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+      - run: "curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
+          | python3 - --version 1.1.0b2"
       - run: poetry build
       - run: POETRY_HTTP_BASIC_PYPI_PASSWORD=${PYPI_PASSWORD} poetry publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - checkout
       - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
-      - run: poetry install --extras "dev-dependencies"
+      - run: poetry install
       - run: black --check .
       - run: mypy -p "brainframe.cli"
   upload_to_pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - checkout
       - run: "curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
-          | python3 - --version 1.1.0b2"
+          | python3 - --version 1.1.0"
       - run: poetry install --no-root
       - run: poetry run black --check .
       - run: poetry run mypy -p "brainframe.cli"
@@ -36,6 +36,6 @@ jobs:
     steps:
       - checkout
       - run: "curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
-          | python3 - --version 1.1.0b2"
+          | python3 - --version 1.1.0"
       - run: poetry build
       - run: POETRY_HTTP_BASIC_PYPI_PASSWORD=${PYPI_PASSWORD} poetry publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
       - image: circleci/python:3.6
     steps:
       - checkout
-      - run: pip3 install --upgrade mypy black
+      - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
+      - run: poetry install --extras "dev-dependencies"
       - run: black --check .
       - run: mypy -p "brainframe.cli"
   upload_to_pypi:
@@ -33,6 +34,6 @@ jobs:
 
     steps:
       - checkout
-      - run: pip3 install --upgrade poetry
+      - run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3
       - run: poetry build
       - run: POETRY_HTTP_BASIC_PYPI_PASSWORD=${PYPI_PASSWORD} poetry publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - checkout
       - run: "curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
           | python3 - --version 1.1.0b2"
-      - run: poetry install
+      - run: poetry install --no-root
       - run: black --check .
       - run: mypy -p "brainframe.cli"
   upload_to_pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ jobs:
       - run: "curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
           | python3 - --version 1.1.0b2"
       - run: poetry install --no-root
-      - run: black --check .
-      - run: mypy -p "brainframe.cli"
+      - run: poetry run black --check .
+      - run: poetry run mypy -p "brainframe.cli"
   upload_to_pypi:
     docker:
       - image: circleci/python:3.6


### PR DESCRIPTION
This ensures that developers and the CI are using the same versions of our linting tools. As a bonus, Poetry is now installed using the install script, ensuring that its dependencies don't conflict with ours.