### PR TITLE
Improve permission errors for the update and compose subcommands

### DIFF
--- a/brainframe/cli/commands/compose.py
+++ b/brainframe/cli/commands/compose.py
@@ -8,21 +8,6 @@ from .utils import command
 
 @command("compose")
 def compose():
-    # Check first if the user has permission to interact with Docker
-    if not os_utils.is_root():
-        if not os_utils.currently_in_group("docker"):
-            error_message = i18n.t("compose.docker-bad-permissions") + "\n"
-
-            if os_utils.added_to_group("docker"):
-                # The user is in the group, they just need to restart
-                error_message += i18n.t("compose.restart-for-group-access")
-            else:
-                # The user is not in the group, so they need to either add
-                # themselves or use sudo
-                error_message += i18n.t("compose.retry-with-sudo-or-group")
-
-            print_utils.fail(error_message)
-
     install_path = env_vars.install_path.get()
     docker_compose.assert_installed(install_path)
     docker_compose.run(install_path, sys.argv[2:])

--- a/brainframe/cli/docker_compose.py
+++ b/brainframe/cli/docker_compose.py
@@ -108,15 +108,14 @@ def check_existing_version(install_path: Path):
 
 def _assert_has_docker_permissions():
     """Fails if the user does not have permissions to interact with Docker"""
-    if not os_utils.is_root():
-        if not os_utils.currently_in_group("docker"):
-            error_message = (
-                i18n.t("general.docker-bad-permissions")
-                + "\n"
-                + _group_recommendation_message("docker")
-            )
+    if not (os_utils.is_root() or os_utils.currently_in_group("docker")):
+        error_message = (
+            i18n.t("general.docker-bad-permissions")
+            + "\n"
+            + _group_recommendation_message("docker")
+        )
 
-            print_utils.fail(error_message)
+        print_utils.fail(error_message)
 
 
 def _assert_has_write_permissions(path: Path):

--- a/brainframe/cli/docker_compose.py
+++ b/brainframe/cli/docker_compose.py
@@ -1,6 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Tuple, cast, TextIO
 import yaml
 import i18n
 import os
@@ -95,7 +95,10 @@ def check_download_version(
             stdout=subprocess.PIPE,
             encoding="utf-8",
         )
-        version = result.stdout.readline().strip()
+        # stdout is a file-like object opened in text mode when the encoding
+        # argument is "utf-8"
+        stdout = cast(TextIO, result.stdout)
+        version = stdout.readline().strip()
 
     return subdomain, auth_flags, version
 

--- a/brainframe/cli/docker_compose.py
+++ b/brainframe/cli/docker_compose.py
@@ -47,7 +47,7 @@ def run(install_path: Path, commands: List[str]):
 
 
 def download(target: Path, version="latest"):
-    _assert_has_write_permissions(target)
+    _assert_has_write_permissions(target.parent)
 
     subdomain, auth_flags, version = check_download_version(version=version)
 

--- a/brainframe/cli/docker_compose.py
+++ b/brainframe/cli/docker_compose.py
@@ -129,9 +129,9 @@ def _assert_has_write_permissions(path: Path):
     print()
 
     if path.stat().st_gid == os_utils.BRAINFRAME_GROUP_ID:
-        error_message += _group_recommendation_message("brainframe")
+        error_message += " " + _group_recommendation_message("brainframe")
     else:
-        error_message += i18n.t(
+        error_message += " " + i18n.t(
             "general.unexpected-group-for-file", path=path, group="brainframe"
         )
 

--- a/brainframe/cli/docker_compose.py
+++ b/brainframe/cli/docker_compose.py
@@ -64,8 +64,9 @@ def download(target: Path, version: str = "latest") -> None:
         os_utils.give_brainframe_group_rw_access([target])
 
 
-def check_download_version(version: str = "latest") -> \
-        Tuple[str, List[str], str]:
+def check_download_version(
+    version: str = "latest",
+) -> Tuple[str, List[str], str]:
     subdomain = ""
     auth_flags = []
 

--- a/brainframe/cli/translations/compose.en.yml
+++ b/brainframe/cli/translations/compose.en.yml
@@ -1,8 +1,0 @@
-en:
-  docker-bad-permissions: "Your user does not have sufficient privileges to
-  use Docker."
-  restart-for-group-access: "Your user has been added to the \"docker\" group
-  but you must restart to apply this change. Alternatively, you can try again
-  with sudo."
-  retry-with-sudo-or-group: "Please try again with sudo or consider adding your
-  user to the \"docker\" group."

--- a/brainframe/cli/translations/general.en.yml
+++ b/brainframe/cli/translations/general.en.yml
@@ -12,7 +12,7 @@ en:
   to a custom location, ensure that the %{install_env_var} environment variable
   has been set."
   mkdir-permission-denied: "Permission denied while making directory
-  %{directory}, trying with sudo."
+  %{directory}, trying as root."
   staging-missing-credentials: "The %{username_env_var} and %{password_env_var}
   variables must be set to access staging."
   user-not-root: "This command must be run as root!"
@@ -20,11 +20,11 @@ en:
   use Docker."
   restart-for-group-access: "Your user has been added to the \"%{group}\"
   group but you must restart to apply this change. Alternatively, you can try
-  again with sudo."
-  retry-with-sudo-or-group: "Please try again with sudo or consider adding your
+  again as root."
+  retry-as-root-or-group: "Please try again as root or consider adding your
   user to the \"%{group}\" group."
   file-bad-write-permissions: "Your user does not have write access to
   \"%{path}\"."
-  unexpected-group-for-file: "File \"%{path}\" is not part of the
+  unexpected-group-for-file: "File \"%{path}\" is not owned by the
   \"%{group}\" group, but probably should be. Please add this file to the group
-  or try again with sudo."
+  or try again as root."

--- a/brainframe/cli/translations/general.en.yml
+++ b/brainframe/cli/translations/general.en.yml
@@ -22,7 +22,7 @@ en:
   group but you must restart to apply this change. Alternatively, you can try
   again with sudo."
   retry-with-sudo-or-group: "Please try again with sudo or consider adding your
-  user to the \"%{group_name}\" group."
+  user to the \"%{group}\" group."
   file-bad-write-permissions: "Your user does not have write access to
   \"%{path}\"."
   unexpected-group-for-file: "File \"%{path}\" is not part of the

--- a/brainframe/cli/translations/general.en.yml
+++ b/brainframe/cli/translations/general.en.yml
@@ -16,3 +16,15 @@ en:
   staging-missing-credentials: "The %{username_env_var} and %{password_env_var}
   variables must be set to access staging."
   user-not-root: "This command must be run as root!"
+  docker-bad-permissions: "Your user does not have sufficient privileges to
+  use Docker."
+  restart-for-group-access: "Your user has been added to the \"%{group}\"
+  group but you must restart to apply this change. Alternatively, you can try
+  again with sudo."
+  retry-with-sudo-or-group: "Please try again with sudo or consider adding your
+  user to the \"%{group_name}\" group."
+  file-bad-write-permissions: "Your user does not have write access to
+  \"%{path}\"."
+  unexpected-group-for-file: "File \"%{path}\" is not part of the
+  \"%{group}\" group, but probably should be. Please add this file to the group
+  or try again with sudo."


### PR DESCRIPTION
A check is done preemptively to guess if the user has the necessary permissions to do these operations and provides guidance if necessary. This prevents the CLI from crashing later on with unhelpful stack traces.

Fixes #2.